### PR TITLE
Rename `mdast-unlink` to `remark-unlink`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-[![npm](https://nodei.co/npm/mdast-unlink.png)](https://npmjs.com/package/mdast-unlink)
+[![npm](https://nodei.co/npm/remark-unlink.png)](https://npmjs.com/package/remark-unlink)
 
-# mdast-unlink
+# remark-unlink
 
 [![Build Status][travis-badge]][travis] [![Dependency Status][david-badge]][david]
 
-Remove all links, references and definitions. A plugin for [mdast].
+Remove all links, references and definitions. A plugin for [remark].
 
 Original motivation was to process Markdown documents in a way that would make it easier to read as a plain text.
 
-[mdast]: https://github.com/wooorm/mdast
+[remark]: https://github.com/wooorm/remark
 
-[travis]: https://travis-ci.org/eush77/mdast-unlink
-[travis-badge]: https://travis-ci.org/eush77/mdast-unlink.svg?branch=master
-[david]: https://david-dm.org/eush77/mdast-unlink
-[david-badge]: https://david-dm.org/eush77/mdast-unlink.png
+[travis]: https://travis-ci.org/eush77/remark-unlink
+[travis-badge]: https://travis-ci.org/eush77/remark-unlink.svg?branch=master
+[david]: https://david-dm.org/eush77/remark-unlink
+[david-badge]: https://david-dm.org/eush77/remark-unlink.png
 
 ## Example
 
@@ -41,7 +41,7 @@ More content.
 Imagine section titles and URLs being longer. On an ebook reader or a piece paper they are not only useless but looking ugly as well.
 
 ```
-$ mdast -u unlink test/input.md
+$ remark -u unlink test/input.md
 ```
 
 output:
@@ -64,22 +64,22 @@ More content.
 ## API
 
 ```js
-var mdastUnlink = require('mdast-unlink');
+var remarkUnlink = require('remark-unlink');
 
-mdast.use(mdastUnlink)
+remark.use(remarkUnlink)
 ```
 
 Or from the command line:
 
 ```
-$ mdast --use mdast-unlink
+$ remark --use remark-unlink
 ```
 
 
 ## Install
 
 ```
-npm install mdast-unlink
+npm install remark-unlink
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mdast-unlink",
+  "name": "remark-unlink",
   "version": "1.0.1",
   "description": "Remove all links, references and definitions",
   "author": "Eugene Sharygin <eush77@gmail.com>",
@@ -10,17 +10,17 @@
   "files": [
     "index.js"
   ],
-  "homepage": "https://github.com/eush77/mdast-unlink",
-  "repository": "eush77/mdast-unlink",
+  "homepage": "https://github.com/eush77/remark-unlink",
+  "repository": "eush77/remark-unlink",
   "bugs": {
-    "url": "https://github.com/eush77/mdast-unlink/issues"
+    "url": "https://github.com/eush77/remark-unlink/issues"
   },
   "keywords": [
     "definitions",
     "filter",
     "images",
     "links",
-    "mdast",
+    "remark",
     "plaintext",
     "references",
     "remove",
@@ -32,7 +32,7 @@
     "unist-util-select": "^1.0.0"
   },
   "devDependencies": {
-    "mdast": "^1.2.0",
+    "remark": "^3.0.0",
     "tape": "^4.2.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var mdastUnlink = require('..');
+var remarkUnlink = require('..');
 
-var mdast = require('mdast'),
+var remark = require('remark'),
     test = require('tape');
 
 var fs = require('fs'),
@@ -10,10 +10,10 @@ var fs = require('fs'),
 
 
 test(function (t) {
-  t.equal(mdast.use(mdastUnlink).process(read('input1')),
-          mdast.process(read('output1')));
-  t.equal(mdast.use(mdastUnlink).process(read('input2')),
-          mdast.process(read('output2')));
+  t.equal(remark.use(remarkUnlink).process(read('input1')),
+          remark.process(read('output1')));
+  t.equal(remark.use(remarkUnlink).process(read('input2')),
+          remark.process(read('output2')));
   t.end();
 });
 


### PR DESCRIPTION
You’ll still need to:
-   Rename the project on GitHub to `remark-contributors`;
-   Publish `remark-contributors` to npm;
-   Preferably update `mdast-contributors` on npm to show a deprecation message.

I’d be up for doing the last two for you if you’d give me access to npm :)

P.S. let me know if I can help in any other way. :smile: 
